### PR TITLE
Update the module to work with PHP 7.2 and Webform

### DIFF
--- a/ux_filters/src/Plugin/UxFilter/ListFieldCheckboxes.php
+++ b/ux_filters/src/Plugin/UxFilter/ListFieldCheckboxes.php
@@ -34,10 +34,9 @@ class ListFieldCheckboxes extends UxFilterBase {
     unset($element['#options']['All']);
     $user_input = $form_state->getUserInput();
     if ($user_input[$element_id] == 'All') {
-      $user_input[$element_id] = '';
+      $user_input[$element_id] = array();
       $form_state->setUserInput($user_input);
     }
-    // kint($element);
   }
 
 }

--- a/ux_form/ux_form.module
+++ b/ux_form/ux_form.module
@@ -177,6 +177,10 @@ function ux_form_get_config() {
  *     Properties used: #id, #attributes, #children.
  */
 function ux_form_preprocess_container(array &$variables) {
+  if (isset($variables['attributes']) && $variables['attributes'] instanceof Drupal\Core\Template\Attribute) {
+    $variables['attributes'] = $variables['attributes']->toArray();
+  }
+
   if (isset($variables['attributes'])) {
     ux_form_attribute_convert($variables['attributes'], $variables['element']);
   }
@@ -186,15 +190,20 @@ function ux_form_preprocess_container(array &$variables) {
  * Implements template_preprocess_fieldset().
  */
 function ux_form_preprocess_fieldset(&$variables) {
-  if (isset($variables['attributes'])) {
+  if (isset($variables['attributes']) && $variables['attributes'] instanceof Drupal\Core\Template\Attribute) {
+    $variables['attributes'] = $variables['attributes']->toArray();
+  }
+
+  if (isset($variables['attributes']) && is_array($variables['attributes'])) {
     ux_form_attribute_convert($variables['attributes'], $variables['element']);
-  }
-  if (!isset($variables['legend']['title'])) {
-    // Add a .no-legend class if no title is provided.
-    $variables['attributes']['class'][] = 'no-legend';
-  }
-  else {
-    $variables['attributes']['class'][] = 'has-legend';
+
+    if (!isset($variables['legend']['title'])) {
+      // Add a .no-legend class if no title is provided.
+      $variables['attributes']['class'][] = 'no-legend';
+    }
+    else {
+      $variables['attributes']['class'][] = 'has-legend';
+    }
   }
 }
 


### PR DESCRIPTION
A few sections of the UX module are not working with PHP 7.2.

Exposed Filters of checkboxes are confused if no checkboxes are set.  The default is no longer the "All" option, but an empty Array of options.  PHP 7.2 throws a nasty error because it cannot convert a string to an empty array.

Also, the Webform module is starting to use a `Drupal\Core\Template\Attribute` class to manage attributes on some forms. UX Form now exports those to a more basic Array also accepted by the render system and adds a few classes as desired.